### PR TITLE
Compute Paths in Parallel

### DIFF
--- a/common/src/main/java/net/whimxiqal/journey/search/ItineraryTrial.java
+++ b/common/src/main/java/net/whimxiqal/journey/search/ItineraryTrial.java
@@ -95,14 +95,16 @@ public class ItineraryTrial implements Resulted {
 
     // Collect trials as they finish.
     while (!failed && !pathTrialFutures.isEmpty()) {
-      if (session.state.shouldStop()) {
-        // Cancel all incomplete paths.
-        pathTrialFutures.forEach(trialFuture -> {
-          trialFuture.cancel(false);
-        });
+      synchronized (this) {
+        if (session.state.shouldStop()) {
+          // Cancel all incomplete paths.
+          pathTrialFutures.forEach(trialFuture -> {
+            trialFuture.cancel(false);
+          });
 
-        session.markStopped();
-        return new TrialResult(Optional.empty(), true);
+          session.markStopped();
+          return new TrialResult(Optional.empty(), true);
+        }
       }
 
       try {

--- a/common/src/main/java/net/whimxiqal/journey/search/ItineraryTrial.java
+++ b/common/src/main/java/net/whimxiqal/journey/search/ItineraryTrial.java
@@ -125,15 +125,6 @@ public class ItineraryTrial implements Resulted {
       }
     }
 
-    // Collect all remaining trials, if any incomplete ones exist.
-    pathTrialFutures.forEach(trialFuture -> {
-      try {
-        completedPathTrials.add(trialFuture.get());
-      } catch (InterruptedException | ExecutionException e) {
-        throw new RuntimeException(e);
-      }
-    });
-
     // Finish up processing trials.
     boolean changedProblem = false;
 
@@ -149,6 +140,22 @@ public class ItineraryTrial implements Resulted {
       Journey.get().dispatcher().dispatch(new StopItinerarySearchEvent(session, this));
       pathTrialFutures.forEach(trialFuture -> {
         trialFuture.cancel(false);
+      });
+
+      // Collect all remaining trials, if any incomplete ones exist.
+      pathTrialFutures.forEach(trialFuture -> {
+        try {
+          completedPathTrials.add(trialFuture.get());
+        } catch (InterruptedException | ExecutionException e) {
+          throw new RuntimeException(e);
+        }
+      });
+
+      // Process PathTrial for cache reasons if it succeeded, even on fail.
+      completedPathTrials.forEach(pathTrial -> {
+        if (pathTrial.path().isPresent()) {
+
+        }
       });
 
       return new TrialResult(Optional.empty(), changedProblem);


### PR DESCRIPTION
The goal of this PR is to resolve #32.

The tasks that need to be done for this are (as listed in the issue):

- [x] Adding suitable `Future` return values from a path trial's search
- [x] Thread-safe cancel methods on each of the path-trial's search
    - [x] If any of the paths fail during the `ItineraryTrial`, we should try to cancel all of the ongoing `PathTrials`. If they in fact returned canceled, then we just ignore whatever else is in the result.
    - [ ] If any of them actually succeed even if they were cancelled, then we should still treat that like a success for caching purposes.
- [x] Kicking off _all_ of the `PathTrials` during an `ItineraryTrial` and wait for them to all complete (and cancel, if needed, as described above)
- [ ] Today, we have a config parameter that limits how many `SearchSessions` may be going at one time. Today, this effectively limits how many `PathTrials` are searching, which in turn limits how much memory the plugin can possibly use, since each of the `PathTrials` have a limited number of visited nodes during its A* search. This new functionality invalidates that assumption, since each `SearchSession` may now have multiple searches running in parallel. So, we could instead change the config parameter to something that tracks the maximum number of path algorithms running at one time (we can keep the same name, just change its description). But, we actually still have a problem: this should probably be its own ticket:
    - We can theoretically lock up all the threads on the system, blocking out all other plugins' asynchronous tasks (assuming the player's max searches config parameter is high enough). This can be fixed by instead having a maximum number of threads that can be used at a time. Since we never have multiple path trials running at once on the same thread, then this also keeps the memory usage under a maximum. So, we should do this instead.