### PR TITLE
[#53] Concurrency Bug Fixes

### DIFF
--- a/api/src/main/java/net/whimxiqal/journey/DestinationImpl.java
+++ b/api/src/main/java/net/whimxiqal/journey/DestinationImpl.java
@@ -23,9 +23,6 @@
 
 package net.whimxiqal.journey;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
 import net.kyori.adventure.text.Component;
@@ -63,4 +60,5 @@ class DestinationImpl implements Destination {
   public Optional<String> permission() {
     return Optional.ofNullable(permission);
   }
+
 }

--- a/bukkit/src/main/java/net/whimxiqal/journey/bukkit/JourneyBukkit.java
+++ b/bukkit/src/main/java/net/whimxiqal/journey/bukkit/JourneyBukkit.java
@@ -29,7 +29,7 @@ import net.whimxiqal.journey.command.JourneyConnectorProvider;
 import net.whimxiqal.journey.bukkit.config.BukkitConfigManager;
 import net.whimxiqal.journey.bukkit.listener.DeathListener;
 import net.whimxiqal.journey.bukkit.listener.NetherListener;
-import net.whimxiqal.journey.bukkit.search.listener.PlayerSearchListener;
+import net.whimxiqal.journey.bukkit.search.listener.PlayerListener;
 import net.whimxiqal.journey.bukkit.util.BukkitLogger;
 import net.whimxiqal.journey.bukkit.util.BukkitSchedulingManager;
 import net.whimxiqal.mantle.paper.PaperRegistrarProvider;
@@ -88,7 +88,7 @@ public final class JourneyBukkit extends JavaPlugin {
     registrar.register(JourneyConnectorProvider.connector());
 
     Bukkit.getPluginManager().registerEvents(new NetherListener(), this);
-    Bukkit.getPluginManager().registerEvents(new PlayerSearchListener(), this);
+    Bukkit.getPluginManager().registerEvents(new PlayerListener(), this);
     Bukkit.getPluginManager().registerEvents(new DeathListener(), this);
   }
 

--- a/bukkit/src/main/java/net/whimxiqal/journey/bukkit/search/listener/PlayerListener.java
+++ b/bukkit/src/main/java/net/whimxiqal/journey/bukkit/search/listener/PlayerListener.java
@@ -1,0 +1,65 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) whimxiqal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.whimxiqal.journey.bukkit.search.listener;
+
+import java.util.UUID;
+import net.whimxiqal.journey.Journey;
+import net.whimxiqal.journey.Cell;
+import net.whimxiqal.journey.bukkit.util.BukkitUtil;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+
+public class PlayerListener implements Listener {
+
+  public static final long VISITATION_TIMEOUT_MS = 10;  // Any visits with 10 ms
+  private long lastVisitTime = 0;
+
+  /**
+   * Handler for when players move throughout the world.
+   * This allows us to update the last known location so player journeys
+   * know which particles to show.
+   *
+   * @param event the event
+   */
+  @EventHandler
+  public void onPlayerMove(PlayerMoveEvent event) {
+    long now = System.currentTimeMillis();
+    if (now < lastVisitTime + VISITATION_TIMEOUT_MS) {
+      // ignore movements if they're too frequent
+      return;
+    }
+    lastVisitTime = now;
+    Cell cell = BukkitUtil.cell(event.getTo());
+    UUID playerUuid = event.getPlayer().getUniqueId();
+    Journey.get().searchManager().registerLocation(playerUuid, cell);
+  }
+
+  @EventHandler
+  public void onPlayerJoin(PlayerJoinEvent event) {
+    Journey.get().cachedDataProvider().personalWaypointCache().update(event.getPlayer().getUniqueId(), true);
+  }
+
+}

--- a/common/src/main/java/net/whimxiqal/journey/ProxyImpl.java
+++ b/common/src/main/java/net/whimxiqal/journey/ProxyImpl.java
@@ -89,6 +89,9 @@ public class ProxyImpl implements Proxy {
   }
 
   public void dataManager(DataManager dataManager) {
+    if (schedulingManager.isMainThread()) {
+      Journey.logger().warn("Data manager accessed on main thread, this is likely a mistake.");
+    }
     this.dataManager = dataManager;
   }
 
@@ -103,6 +106,9 @@ public class ProxyImpl implements Proxy {
 
   @Override
   public PlatformProxy platform() {
+    if (!schedulingManager.isMainThread()) {
+      Journey.logger().warn("Platform proxy accessed on async thread. This is likely a mistake bug, please notify the developer.");
+    }
     return platformProxy;
   }
 

--- a/common/src/main/java/net/whimxiqal/journey/ProxyImpl.java
+++ b/common/src/main/java/net/whimxiqal/journey/ProxyImpl.java
@@ -89,14 +89,14 @@ public class ProxyImpl implements Proxy {
   }
 
   public void dataManager(DataManager dataManager) {
-    if (schedulingManager.isMainThread()) {
-      Journey.logger().warn("Data manager accessed on main thread, this is likely a mistake.");
-    }
     this.dataManager = dataManager;
   }
 
   @Override
   public DataManager dataManager() {
+    if (schedulingManager.isMainThread()) {
+      Journey.logger().warn("Data manager accessed on the main thread. This is likely a mistake mistake, please notify the developer.");
+    }
     return dataManager;
   }
 

--- a/common/src/main/java/net/whimxiqal/journey/chunk/CentralChunkCache.java
+++ b/common/src/main/java/net/whimxiqal/journey/chunk/CentralChunkCache.java
@@ -43,6 +43,7 @@ import net.whimxiqal.journey.search.PathTrial;
  */
 public class CentralChunkCache {
 
+  private static final int TICKS_PER_DEBUG_LOG = 20;  // once per second
   private final Map<ChunkId, ChunkRequest> requestMap = new HashMap<>();  // this tracks requests keyed by chunk id
   private final Queue<ChunkRequest> requestQueue = new LinkedList<>();  // this tracks requests in order of appearance
   private final Object lock = new Object();
@@ -63,7 +64,7 @@ public class CentralChunkCache {
     requestTaskId = Journey.get().proxy().schedulingManager().scheduleRepeat(this::executeRequests,
         false, 1);  // Once per tick
     loggingTaskId = Journey.get().proxy().schedulingManager().scheduleRepeat(this::broadcastLogs,
-        false, 20); // Once per second
+        false, TICKS_PER_DEBUG_LOG);
   }
 
   /**

--- a/common/src/main/java/net/whimxiqal/journey/chunk/CentralChunkCache.java
+++ b/common/src/main/java/net/whimxiqal/journey/chunk/CentralChunkCache.java
@@ -23,7 +23,6 @@
 
 package net.whimxiqal.journey.chunk;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
@@ -44,6 +43,7 @@ import net.whimxiqal.journey.search.PathTrial;
 public class CentralChunkCache {
 
   private static final int TICKS_PER_DEBUG_LOG = 20;  // once per second
+  private static final int MAX_CHUNK_REQUESTS_PER_TICK = 1024;
   private final Map<ChunkId, ChunkRequest> requestMap = new HashMap<>();  // this tracks requests keyed by chunk id
   private final Queue<ChunkRequest> requestQueue = new LinkedList<>();  // this tracks requests in order of appearance
   private final Object lock = new Object();
@@ -90,8 +90,12 @@ public class CentralChunkCache {
       removedCounter += chunkCache.prune();
 
       // Execute requests
-      addedCounter += requestQueue.size();
+      int completed = 0;
       while (!requestQueue.isEmpty()) {
+        if (completed >= MAX_CHUNK_REQUESTS_PER_TICK) {
+          Journey.logger().debug(String.format("[Chunk Cache] Hit maximum allowed number of chunk requests (%d), %d requests remaining", MAX_CHUNK_REQUESTS_PER_TICK, requestQueue.size()));
+          break;
+        }
         ChunkRequest req = requestQueue.remove();
         requestMap.remove(req.chunkId());
 
@@ -99,7 +103,9 @@ public class CentralChunkCache {
         JourneyChunk snapshot = Journey.get().proxy().platform().toChunk(req.chunkId());
         removedCounter += chunkCache.save(snapshot);
         req.future().complete(snapshot);
+        completed++;
       }
+      addedCounter += completed;
     }
   }
 
@@ -118,34 +124,6 @@ public class CentralChunkCache {
   }
 
   /**
-   * Submits requests to load the chunks with given chunk ids.
-   *
-   * @param chunkIds the ids of the chunks to load
-   */
-  public void loadChunks(Collection<ChunkId> chunkIds) {
-    synchronized (lock) {
-      for (ChunkId chunkId : chunkIds) {
-        // Is this chunk already stored in cache?
-        JourneyChunk maybeChunk = chunkCache.getChunk(chunkId);
-        if (maybeChunk != null) {
-          continue;
-        }
-
-        // Chunk is not stored in cache. Is it already queued?
-        ChunkRequest maybeRequest = requestMap.get(chunkId);
-        if (maybeRequest != null) {
-          continue;
-        }
-
-        // Not stored and not queued. Queue it.
-        maybeRequest = new ChunkRequest(chunkId);
-        requestQueue.add(maybeRequest);
-        requestMap.put(chunkId, maybeRequest);
-      }
-    }
-  }
-
-  /**
    * Get a {@link Future} for a chunk given its id.
    * The future may complete automatically if it is already available in the cache.
    * Otherwise, a request will be submitted and upon the next server tick, a chunk will be provided.
@@ -159,8 +137,8 @@ public class CentralChunkCache {
       // Request chunks for chunks surrounding the requested one, since they may be wanted later
       int chunkX = chunkId.x();
       int chunkZ = chunkId.z();
-      for (int x = chunkX - 1; x <= chunkX + 1; x++) {
-        for (int z = chunkZ - 1; z <= chunkZ + 1; z++) {
+      for (int x = chunkX - 2; x <= chunkX + 2; x++) {
+        for (int z = chunkZ - 2; z <= chunkZ + 2; z++) {
           boolean isRequestedChunk = x == chunkX && z == chunkZ;
           ChunkId innerChunkId = new ChunkId(chunkId.domain(), x, z);
 

--- a/common/src/main/java/net/whimxiqal/journey/chunk/ChunkCache.java
+++ b/common/src/main/java/net/whimxiqal/journey/chunk/ChunkCache.java
@@ -113,4 +113,8 @@ public final class ChunkCache {
         ", chunkList size=" + chunkQueue.size() +
         '}';
   }
+
+  public int remainingSlots() {
+    return maxCachedChunks - chunkMap.size();
+  }
 }

--- a/common/src/main/java/net/whimxiqal/journey/chunk/ChunkCache.java
+++ b/common/src/main/java/net/whimxiqal/journey/chunk/ChunkCache.java
@@ -114,7 +114,4 @@ public final class ChunkCache {
         '}';
   }
 
-  public int remainingSlots() {
-    return maxCachedChunks - chunkMap.size();
-  }
 }

--- a/common/src/main/java/net/whimxiqal/journey/chunk/ChunkCacheBlockProvider.java
+++ b/common/src/main/java/net/whimxiqal/journey/chunk/ChunkCacheBlockProvider.java
@@ -42,12 +42,10 @@ public class ChunkCacheBlockProvider implements BlockProvider {
 
 
   private final ChunkCache chunkCache;
-  private final int maxCachedChunks;
   private final FlagSet flagSet;
 
   public ChunkCacheBlockProvider(int maxCachedChunks, FlagSet flagSet) {
     this.chunkCache = new ChunkCache(maxCachedChunks);
-    this.maxCachedChunks = maxCachedChunks;
     this.flagSet = flagSet;
   }
 
@@ -63,7 +61,7 @@ public class ChunkCacheBlockProvider implements BlockProvider {
     }
 
     // adjust the actual max because we don't want to do more than our cache can actually handle
-    int adjustedMaxChunks = Math.min(maxChunks, maxCachedChunks / 2);
+    int adjustedMaxChunks = Math.min(maxChunks, chunkCache.remainingSlots() / 2);
 
     double xDiff = destination.blockX() - origin.blockX();
     double zDiff = destination.blockZ() - origin.blockZ();

--- a/common/src/main/java/net/whimxiqal/journey/chunk/ChunkCacheBlockProvider.java
+++ b/common/src/main/java/net/whimxiqal/journey/chunk/ChunkCacheBlockProvider.java
@@ -23,8 +23,6 @@
 
 package net.whimxiqal.journey.chunk;
 
-import java.util.LinkedList;
-import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import net.whimxiqal.journey.Cell;
@@ -47,46 +45,6 @@ public class ChunkCacheBlockProvider implements BlockProvider {
   public ChunkCacheBlockProvider(int maxCachedChunks, FlagSet flagSet) {
     this.chunkCache = new ChunkCache(maxCachedChunks);
     this.flagSet = flagSet;
-  }
-
-  /**
-   * Prepare some chunks between origin and destination.
-   *
-   * @param origin      the starting point of where to start preparing chunks
-   * @param destination the end point
-   */
-  public void prepareChunks(Cell origin, Cell destination, int maxChunks) {
-    if (origin.domain() != destination.domain()) {
-      throw new IllegalArgumentException("Origin and destination did not have the same domain");
-    }
-
-    // adjust the actual max because we don't want to do more than our cache can actually handle
-    int adjustedMaxChunks = Math.min(maxChunks, chunkCache.remainingSlots() / 2);
-
-    double xDiff = destination.blockX() - origin.blockX();
-    double zDiff = destination.blockZ() - origin.blockZ();
-
-    final double distance = Math.sqrt(xDiff * xDiff + zDiff * zDiff);
-    final double xUnitComp = xDiff / distance;
-    final double zUnitComp = zDiff / distance;
-
-    // Walk one block at a time directly towards the destination and queue any necessary chunks
-    int lastChunkX = Integer.MIN_VALUE;
-    int lastChunkZ = Integer.MIN_VALUE;
-    double curDist = 0;
-    List<ChunkId> toQueue = new LinkedList<>();
-    while (curDist < distance && toQueue.size() < adjustedMaxChunks) {
-      int chunkX = Math.floorDiv((int) Math.floor(xUnitComp * curDist), CHUNK_SIDE_LENGTH);
-      int chunkZ = Math.floorDiv((int) Math.floor(zUnitComp * curDist), CHUNK_SIDE_LENGTH);
-      if (lastChunkX != chunkX || lastChunkZ != chunkZ) {
-        toQueue.add(new ChunkId(origin.domain(), chunkX, chunkZ));
-        lastChunkX = chunkX;
-        lastChunkZ = chunkZ;
-      }
-      curDist += 1.0;
-    }
-
-    Journey.get().centralChunkCache().loadChunks(toQueue);
   }
 
   @Override

--- a/common/src/main/java/net/whimxiqal/journey/command/JourneyConnectorProvider.java
+++ b/common/src/main/java/net/whimxiqal/journey/command/JourneyConnectorProvider.java
@@ -30,6 +30,7 @@ import net.whimxiqal.journey.Journey;
 import net.whimxiqal.journey.common.JourneyLexer;
 import net.whimxiqal.journey.common.JourneyParser;
 import net.whimxiqal.journey.InternalJourneyPlayer;
+import net.whimxiqal.journey.data.Waypoint;
 import net.whimxiqal.journey.scope.ScopeUtil;
 import net.whimxiqal.journey.util.Permission;
 import net.whimxiqal.mantle.common.CommandSource;
@@ -58,13 +59,18 @@ public class JourneyConnectorProvider {
             .addParameter(Parameter.builder("waypoint")
                 .options(ctx -> {
                   if (ctx.source().type() == CommandSource.Type.PLAYER) {
-                    return Journey.get().proxy().dataManager().personalWaypointManager().getAll(ctx.source().uuid(), false).keySet();
+                    return Journey.get().cachedDataProvider().personalWaypointCache()
+                        .getAll(ctx.source().uuid(), false)
+                        .stream().map(Waypoint::name)
+                        .collect(Collectors.toList());
                   }
                   return Collections.emptyList();
                 })
                 .build())
             .addParameter(Parameter.builder("server-waypoint")
-                .options(ctx -> Journey.get().proxy().dataManager().publicWaypointManager().getAll().keySet())
+                .options(ctx -> Journey.get().cachedDataProvider().publicWaypointCache()
+                    .getAll().stream().map(Waypoint::name)
+                    .collect(Collectors.toList()))
                 .build())
             .addParameter(Parameter.builder("scope")
                 .options(ctx -> ScopeUtil.options(InternalJourneyPlayer.from(ctx.source())))

--- a/common/src/main/java/net/whimxiqal/journey/data/PersonalWaypointManager.java
+++ b/common/src/main/java/net/whimxiqal/journey/data/PersonalWaypointManager.java
@@ -23,19 +23,17 @@
 
 package net.whimxiqal.journey.data;
 
-import java.util.Map;
 import java.util.UUID;
 import net.whimxiqal.journey.Cell;
 import net.whimxiqal.journey.search.SearchSession;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * A general description of how to handle storage for personal search endpoints.
  *
  * @see SearchSession
  */
-public interface PersonalWaypointManager {
+public interface PersonalWaypointManager extends PersonalWaypointProvider {
 
   /**
    * Add a player to a specific cell to the database with a unique name.
@@ -75,30 +73,6 @@ public interface PersonalWaypointManager {
               @NotNull String name) throws DataAccessException;
 
   /**
-   * Check if a player has a personal endpoint at the certain cell location.
-   *
-   * @param playerUuid the player's uuid
-   * @param cell       the cell location
-   * @return true if the cell exists for the given player
-   */
-  default boolean hasWaypoint(@NotNull UUID playerUuid,
-                              @NotNull Cell cell) throws DataAccessException {
-    return getName(playerUuid, cell) != null;
-  }
-
-  /**
-   * Check if a player has a certain named personal endpoint.
-   *
-   * @param playerUuid the player's uuid
-   * @param name       the cell name
-   * @return true if the cell exists for the given player
-   */
-  default boolean hasWaypoint(@NotNull UUID playerUuid,
-                              @NotNull String name) throws DataAccessException {
-    return getWaypoint(playerUuid, name) != null;
-  }
-
-  /**
    * Rename the waypoint.
    *
    * @param uuid    the player's uuid
@@ -107,46 +81,4 @@ public interface PersonalWaypointManager {
    */
   void renameWaypoint(UUID uuid, String name, String newName) throws DataAccessException;
 
-  /**
-   * Get the name of a personal location with a given unique player and cell.
-   *
-   * @param playerUuid the player's uuid
-   * @param cell       the personal location
-   * @return the cell's name, or null if it doesn't exist
-   */
-  @Nullable
-  String getName(@NotNull UUID playerUuid,
-                 @NotNull Cell cell) throws DataAccessException;
-
-  /**
-   * Get a specific cell with a given unique player and name combination.
-   *
-   * @param playerUuid the player's uuid
-   * @param name       the cell name
-   * @return the cell, or null if it doesn't
-   */
-  @Nullable
-  Cell getWaypoint(@NotNull UUID playerUuid,
-                   @NotNull String name) throws DataAccessException;
-
-  boolean isPublic(@NotNull UUID playerUuid,
-                   @NotNull String name) throws DataAccessException;
-
-  /**
-   * Get a list of all personal endpoints for a player.
-   *
-   * @param playerUuid the player's uuid
-   * @param justPublic whether to show only public waypoints
-   * @return all names of cells mapped to their corresponding cells
-   */
-  Map<String, Cell> getAll(@NotNull UUID playerUuid, boolean justPublic) throws DataAccessException;
-
-  /**
-   * Get the number of entries found with this player uuid and the public value
-   *
-   * @param playerUuid the player's uuid
-   * @param justPublic whether to show only public waypoints
-   * @return the number of entries
-   */
-  int getCount(UUID playerUuid, boolean justPublic);
 }

--- a/common/src/main/java/net/whimxiqal/journey/data/PersonalWaypointProvider.java
+++ b/common/src/main/java/net/whimxiqal/journey/data/PersonalWaypointProvider.java
@@ -1,0 +1,101 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) whimxiqal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.whimxiqal.journey.data;
+
+import java.util.List;
+import java.util.UUID;
+import net.whimxiqal.journey.Cell;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public interface PersonalWaypointProvider {
+
+  /**
+   * Check if a player has a personal endpoint at the certain cell location.
+   *
+   * @param playerUuid the player's uuid
+   * @param cell       the cell location
+   * @return true if the cell exists for the given player
+   */
+  default boolean hasWaypoint(@NotNull UUID playerUuid,
+                              @NotNull Cell cell) throws DataAccessException {
+    return getName(playerUuid, cell) != null;
+  }
+
+  /**
+   * Check if a player has a certain named personal endpoint.
+   *
+   * @param playerUuid the player's uuid
+   * @param name       the cell name
+   * @return true if the cell exists for the given player
+   */
+  default boolean hasWaypoint(@NotNull UUID playerUuid,
+                              @NotNull String name) throws DataAccessException {
+    return getWaypoint(playerUuid, name) != null;
+  }
+
+
+  /**
+   * Get the name of a personal location with a given unique player and cell.
+   *
+   * @param playerUuid the player's uuid
+   * @param cell       the personal location
+   * @return the cell's name, or null if it doesn't exist
+   */
+  @Nullable
+  String getName(@NotNull UUID playerUuid,
+                 @NotNull Cell cell) throws DataAccessException;
+
+  /**
+   * Get a specific cell with a given unique player and name combination.
+   *
+   * @param playerUuid the player's uuid
+   * @param name       the cell name
+   * @return the cell, or null if it doesn't
+   */
+  @Nullable
+  Cell getWaypoint(@NotNull UUID playerUuid,
+                   @NotNull String name) throws DataAccessException;
+
+  boolean isPublic(@NotNull UUID playerUuid,
+                   @NotNull String name) throws DataAccessException;
+
+  /**
+   * Get an unmodifiable list of all personal endpoints for a player.
+   *
+   * @param playerUuid the player's uuid
+   * @param justPublic whether to show only public waypoints
+   * @return all names of cells mapped to their corresponding cells
+   */
+  List<Waypoint> getAll(@NotNull UUID playerUuid, boolean justPublic) throws DataAccessException;
+
+  /**
+   * Get the number of entries found with this player uuid and the public value
+   *
+   * @param playerUuid the player's uuid
+   * @param justPublic whether to show only public waypoints
+   * @return the number of entries
+   */
+  int getCount(UUID playerUuid, boolean justPublic);
+}

--- a/common/src/main/java/net/whimxiqal/journey/data/PublicWaypointProvider.java
+++ b/common/src/main/java/net/whimxiqal/journey/data/PublicWaypointProvider.java
@@ -23,45 +23,64 @@
 
 package net.whimxiqal.journey.data;
 
+import java.util.List;
 import net.whimxiqal.journey.Cell;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
-/**
- * A manager to handle public endpoints.
- */
-public interface PublicWaypointManager extends PublicWaypointProvider {
+public interface PublicWaypointProvider {
 
-  /**
-   * Add a server endpoint.
-   *
-   * @param cell the cell to add
-   * @param name the name of the location
-   * @throws IllegalArgumentException for invalid inputs
-   */
-  void add(@NotNull Cell cell, @NotNull String name)
-      throws IllegalArgumentException, DataAccessException;
 
   /**
-   * Remove a cell. Name is irrelevant. Does nothing if cell isn't saved.
+   * Check if a saved cell exists at this location.
    *
    * @param cell the cell location
+   * @return true if the cell exists
    */
-  void remove(@NotNull Cell cell) throws DataAccessException;
+  default boolean hasWaypoint(@NotNull Cell cell) throws DataAccessException {
+    return getName(cell) != null;
+  }
 
   /**
-   * Remove a cell from the database by name. Cell location is irrelevant.
-   * Does nothing if the name doesn't exist
+   * Check if a saved cell exists with this name.
    *
-   * @param name the name of the location
+   * @param name the cell name
+   * @return true if the cell exists
    */
-  void remove(@NotNull String name) throws DataAccessException;
+  default boolean hasWaypoint(@NotNull String name) throws DataAccessException {
+    return getWaypoint(name) != null;
+  }
+
 
   /**
-   * Rename a waypoint.
+   * Get the name of a saved location.
    *
-   * @param name    the name
-   * @param newName the new name
+   * @param cell the saved location
+   * @return the cell's name, or null if it doesn't exist
    */
-  void renameWaypoint(String name, String newName) throws DataAccessException;
+  @Nullable
+  String getName(@NotNull Cell cell) throws DataAccessException;
 
+  /**
+   * Get a specific cell by its given name.
+   *
+   * @param name the cell name
+   * @return the cell, or null if it doesn't
+   */
+  @Nullable
+  Cell getWaypoint(@NotNull String name) throws DataAccessException;
+
+  /**
+   * Get a list of all saved endpoints.
+   *
+   * @return all names of cells mapped to their corresponding cells
+   */
+  List<Waypoint> getAll() throws DataAccessException;
+
+  /**
+   * Get the total number of waypoints
+   *
+   * @return waypoint count
+   */
+  int getCount();
 }

--- a/common/src/main/java/net/whimxiqal/journey/data/Waypoint.java
+++ b/common/src/main/java/net/whimxiqal/journey/data/Waypoint.java
@@ -21,39 +21,14 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.whimxiqal.journey.bukkit.search.listener;
+package net.whimxiqal.journey.data;
 
-import java.util.UUID;
-import net.whimxiqal.journey.Journey;
 import net.whimxiqal.journey.Cell;
-import net.whimxiqal.journey.bukkit.util.BukkitUtil;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
-import org.bukkit.event.player.PlayerMoveEvent;
+import org.jetbrains.annotations.NotNull;
 
-public class PlayerSearchListener implements Listener {
-
-  public static final long VISITATION_TIMEOUT_MS = 10;  // Any visits with 10 ms
-  private long lastVisitTime = 0;
-
-  /**
-   * Handler for when players move throughout the world.
-   * This allows us to update the last known location so player journeys
-   * know which particles to show.
-   *
-   * @param event the event
-   */
-  @EventHandler
-  public void onPlayerMove(PlayerMoveEvent event) {
-    long now = System.currentTimeMillis();
-    if (now < lastVisitTime + VISITATION_TIMEOUT_MS) {
-      // ignore movements if they're too frequent
-      return;
-    }
-    lastVisitTime = now;
-    Cell cell = BukkitUtil.cell(event.getTo());
-    UUID playerUuid = event.getPlayer().getUniqueId();
-    Journey.get().searchManager().registerLocation(playerUuid, cell);
+public record Waypoint(String name, Cell location, boolean publicity) implements Comparable<Waypoint> {
+  @Override
+  public int compareTo(@NotNull Waypoint o) {
+    return String.CASE_INSENSITIVE_ORDER.compare(name, o.name);
   }
-
 }

--- a/common/src/main/java/net/whimxiqal/journey/data/cache/CachedDataProvider.java
+++ b/common/src/main/java/net/whimxiqal/journey/data/cache/CachedDataProvider.java
@@ -21,43 +21,29 @@
  * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package net.whimxiqal.journey;
+package net.whimxiqal.journey.data.cache;
 
-import java.nio.file.Path;
-import net.kyori.adventure.platform.AudienceProvider;
-import net.whimxiqal.journey.config.ConfigManager;
-import net.whimxiqal.journey.data.DataManager;
-import net.whimxiqal.journey.manager.SchedulingManager;
-import net.whimxiqal.journey.navigation.PlatformProxy;
-import net.whimxiqal.journey.util.CommonLogger;
+public class CachedDataProvider {
 
-public interface Proxy {
+  private final PersonalWaypointCache personalWaypointCache = new PersonalWaypointCache();
+  private final PublicWaypointCache publicWaypointCache = new PublicWaypointCache();
 
-  CommonLogger logger();
-
-  Path dataFolder();
-
-  AudienceProvider audienceProvider();
-
-  ConfigManager configManager();
-
-  SchedulingManager schedulingManager();
-
-  DataManager dataManager();
-
-  PlatformProxy platform();
-
-  String version();
-
-  default void initialize() {
-    logger().initialize();
-    dataManager().initialize();
-    schedulingManager().initialize();
+  public void initialize() {
+    personalWaypointCache().initialize();
+    publicWaypointCache().initialize();
   }
 
-  default void shutdown() {
-    logger().shutdown();
-    audienceProvider().close();
-    schedulingManager().shutdown();
+  public void shutdown() {
+    personalWaypointCache().shutdown();
+    // public waypoint cache does need to be shutdown
   }
+
+  public PersonalWaypointCache personalWaypointCache() {
+    return personalWaypointCache;
+  }
+
+  public PublicWaypointCache publicWaypointCache() {
+    return publicWaypointCache;
+  }
+
 }

--- a/common/src/main/java/net/whimxiqal/journey/data/cache/PersonalWaypointCache.java
+++ b/common/src/main/java/net/whimxiqal/journey/data/cache/PersonalWaypointCache.java
@@ -1,0 +1,169 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) whimxiqal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.whimxiqal.journey.data.cache;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import net.whimxiqal.journey.Cell;
+import net.whimxiqal.journey.Journey;
+import net.whimxiqal.journey.data.DataAccessException;
+import net.whimxiqal.journey.data.PersonalWaypointProvider;
+import net.whimxiqal.journey.data.Waypoint;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class PersonalWaypointCache implements PersonalWaypointProvider {
+
+  /**
+   * Time until a request for info causes an update
+   */
+  private static final long DATA_SOFT_LIFETIME_MS = 1000 * 60;  // 1 minute
+
+  /**
+   * Time until cached data is purged
+   */
+  private static final long DATA_HARD_LIFETIME_MS = 1000 * 60 * 60;  // 1 hour
+  private static final int PURGE_PERIOD_TICKS = 20 * 60; // 1 minute
+  private final Map<UUID, PersonalWaypointInformation> information = new ConcurrentHashMap<>();
+  private UUID purgeTaskId = null;
+
+  public void initialize() {
+    purgeTaskId = Journey.get().proxy().schedulingManager().scheduleRepeat(() -> {
+      List<UUID> toRemove = new LinkedList<>();
+      for (Map.Entry<UUID, PersonalWaypointInformation> entry : information.entrySet()) {
+        if (entry.getValue().timestamp + DATA_HARD_LIFETIME_MS < System.currentTimeMillis()) {
+          toRemove.add(entry.getKey());
+        }
+      }
+      for (UUID playerUuid : toRemove) {
+        information.remove(playerUuid);
+      }
+    }, false, PURGE_PERIOD_TICKS);
+  }
+
+  public void shutdown() {
+    if (purgeTaskId != null) {
+      Journey.get().proxy().schedulingManager().cancelTask(purgeTaskId);
+      purgeTaskId = null;
+    }
+  }
+
+  /**
+   * Updates the cache for the given player. If force is false, then the cached
+   * data will only be updated if enough time has passed and the data is deemed stale.
+   *
+   * @param playerUuid the player's uuid
+   * @param force      whether to force an update, even if the lifetime of the data has not expired
+   * @return a future, to be completed once the update is complete
+   */
+  public Future<Void> update(UUID playerUuid, boolean force) {
+    PersonalWaypointInformation info = information.get(playerUuid);
+    if (info == null) {
+      info = new PersonalWaypointInformation(Collections.emptyList());
+      info.refreshing.set(true);
+      information.put(playerUuid, info);  // just put in blank info
+      return sendInfoRequest(playerUuid);
+    }
+    if (info.refreshing.get()) {
+      return CompletableFuture.completedFuture(null);  // already in progress, do nothing
+    }
+    if (info.timestamp + DATA_SOFT_LIFETIME_MS < System.currentTimeMillis() || force) {
+      boolean setRefreshing = info.refreshing.compareAndSet(false, true);
+      // only send request if we actually are the ones to set the refreshing flag
+      if (setRefreshing) {
+        return sendInfoRequest(playerUuid);
+      }
+    }
+    return CompletableFuture.completedFuture(null);  // no update needed
+  }
+
+  private Future<Void> sendInfoRequest(UUID playerUuid) {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    Journey.get().proxy().schedulingManager().schedule(() -> {
+      // Request on async thread
+      Collection<Waypoint> waypoints = Journey.get().proxy().dataManager().personalWaypointManager().getAll(playerUuid, false);
+      Journey.get().proxy().schedulingManager().schedule(() -> {
+        // store on main thread
+        information.put(playerUuid, new PersonalWaypointInformation(waypoints));
+        future.complete(null);
+      }, false);
+    }, true);
+    return future;
+  }
+
+  @Override
+  public @Nullable String getName(@NotNull UUID playerUuid, @NotNull Cell cell) throws DataAccessException {
+    throw new UnsupportedOperationException("This operation isn't implemented");
+  }
+
+  @Override
+  public @Nullable Cell getWaypoint(@NotNull UUID playerUuid, @NotNull String name) throws DataAccessException {
+    throw new UnsupportedOperationException("This operation isn't implemented");
+  }
+
+  @Override
+  public boolean isPublic(@NotNull UUID playerUuid, @NotNull String name) throws DataAccessException {
+    throw new UnsupportedOperationException("This operation isn't implemented");
+  }
+
+  @Override
+  public List<Waypoint> getAll(@NotNull UUID playerUuid, boolean justPublic) throws DataAccessException {
+    update(playerUuid, false);
+    return information.get(playerUuid).waypoints
+        .stream()
+        .filter(waypoint -> !justPublic || waypoint.publicity())
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public int getCount(UUID playerUuid, boolean justPublic) {
+    update(playerUuid, false);
+    return information.get(playerUuid).waypoints
+        .stream()
+        .filter(waypoint -> !justPublic || waypoint.publicity())
+        .mapToInt(waypoint -> 1)
+        .sum();
+  }
+
+  private static class PersonalWaypointInformation {
+    final Collection<Waypoint> waypoints;
+    final double timestamp = System.currentTimeMillis();
+    final AtomicBoolean refreshing = new AtomicBoolean(false);
+
+    PersonalWaypointInformation(Collection<Waypoint> waypoints) {
+      this.waypoints = waypoints;
+    }
+
+  }
+
+}

--- a/common/src/main/java/net/whimxiqal/journey/data/cache/PublicWaypointCache.java
+++ b/common/src/main/java/net/whimxiqal/journey/data/cache/PublicWaypointCache.java
@@ -1,0 +1,119 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) whimxiqal
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do
+ * so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+ * AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+ * WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package net.whimxiqal.journey.data.cache;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import net.whimxiqal.journey.Cell;
+import net.whimxiqal.journey.Journey;
+import net.whimxiqal.journey.data.DataAccessException;
+import net.whimxiqal.journey.data.PublicWaypointProvider;
+import net.whimxiqal.journey.data.Waypoint;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class PublicWaypointCache implements PublicWaypointProvider {
+
+  /**
+   * Time until a request for info causes an update
+   */
+  private static final long DATA_SOFT_LIFETIME_MS = 1000 * 60;  // 1 minute
+
+  private PublicWaypointInformation information = new PublicWaypointInformation(Collections.emptyList());
+
+  public void initialize() {
+    sendInfoRequest();
+  }
+
+  /**
+   * Updates the cache. If force is false, then the cached
+   * data will only be updated if enough time has passed and the data is deemed stale.
+   *
+   * @param force whether to force an update, even if the lifetime of the data has not expired
+   * @return a future, to be completed once the update is complete
+   */
+  public Future<Void> update(boolean force) {
+    if (information.refreshing.get()) {
+      return CompletableFuture.completedFuture(null);  // already in progress, do nothing
+    }
+    if (information.timestamp + DATA_SOFT_LIFETIME_MS < System.currentTimeMillis() || force) {
+      boolean setRefreshing = information.refreshing.compareAndSet(false, true);
+      // only send request if we actually are the ones to set the refreshing flag
+      if (setRefreshing) {
+        return sendInfoRequest();
+      }
+    }
+    return CompletableFuture.completedFuture(null);  // no update needed
+  }
+
+  private Future<Void> sendInfoRequest() {
+    CompletableFuture<Void> future = new CompletableFuture<>();
+    Journey.get().proxy().schedulingManager().schedule(() -> {
+      // Request on async thread
+      List<Waypoint> waypoints = Journey.get().proxy().dataManager().publicWaypointManager().getAll();
+      Journey.get().proxy().schedulingManager().schedule(() -> {
+        // store on main thread
+        information = new PublicWaypointInformation(waypoints);
+        future.complete(null);
+      }, false);
+    }, true);
+    return future;
+  }
+
+  @Override
+  public @Nullable String getName(@NotNull Cell cell) throws DataAccessException {
+    throw new UnsupportedOperationException("This operation isn't implemented");
+  }
+
+  @Override
+  public @Nullable Cell getWaypoint(@NotNull String name) throws DataAccessException {
+    throw new UnsupportedOperationException("This operation isn't implemented");
+  }
+
+  @Override
+  public List<Waypoint> getAll() throws DataAccessException {
+    update(false);
+    return information.waypoints;
+  }
+
+  @Override
+  public int getCount() {
+    update(false);
+    return information.waypoints.size();
+  }
+
+  private static class PublicWaypointInformation {
+    final List<Waypoint> waypoints;
+    final double timestamp = System.currentTimeMillis();
+    final AtomicBoolean refreshing = new AtomicBoolean(false);
+
+    PublicWaypointInformation(List<Waypoint> waypoints) {
+      this.waypoints = waypoints;
+    }
+
+  }
+}

--- a/common/src/main/java/net/whimxiqal/journey/data/sql/SqlPersonalWaypointManager.java
+++ b/common/src/main/java/net/whimxiqal/journey/data/sql/SqlPersonalWaypointManager.java
@@ -27,11 +27,12 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Map;
+import java.util.List;
 import java.util.UUID;
+import net.whimxiqal.journey.Cell;
 import net.whimxiqal.journey.data.DataAccessException;
 import net.whimxiqal.journey.data.PersonalWaypointManager;
-import net.whimxiqal.journey.Cell;
+import net.whimxiqal.journey.data.Waypoint;
 import net.whimxiqal.journey.util.UUIDUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -135,7 +136,7 @@ public class SqlPersonalWaypointManager
   }
 
   @Override
-  public Map<String, Cell> getAll(@NotNull UUID playerUuid, boolean justPublic)
+  public List<Waypoint> getAll(@NotNull UUID playerUuid, boolean justPublic)
       throws DataAccessException {
     return this.getWaypoints(playerUuid, justPublic);
   }

--- a/common/src/main/java/net/whimxiqal/journey/data/sql/SqlPublicWaypointManager.java
+++ b/common/src/main/java/net/whimxiqal/journey/data/sql/SqlPublicWaypointManager.java
@@ -23,10 +23,11 @@
 
 package net.whimxiqal.journey.data.sql;
 
-import java.util.Map;
+import java.util.List;
+import net.whimxiqal.journey.Cell;
 import net.whimxiqal.journey.data.DataAccessException;
 import net.whimxiqal.journey.data.PublicWaypointManager;
-import net.whimxiqal.journey.Cell;
+import net.whimxiqal.journey.data.Waypoint;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -78,7 +79,7 @@ public class SqlPublicWaypointManager
   }
 
   @Override
-  public Map<String, Cell> getAll() throws DataAccessException {
+  public List<Waypoint> getAll() throws DataAccessException {
     return getWaypoints(null, false);
   }
 

--- a/common/src/main/java/net/whimxiqal/journey/manager/DomainManager.java
+++ b/common/src/main/java/net/whimxiqal/journey/manager/DomainManager.java
@@ -26,7 +26,6 @@ package net.whimxiqal.journey.manager;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
-import net.whimxiqal.journey.Journey;
 
 public class DomainManager {
 
@@ -34,21 +33,25 @@ public class DomainManager {
   private final Map<UUID, Integer> idToIndex = new HashMap<>();
 
   public int domainIndex(UUID id) {
-    Integer index = idToIndex.get(id);
-    if (index == null) {
-      index = idToIndex.size();
-      indexToId.put(index, id);
-      idToIndex.put(id, index);
+    synchronized (this) {
+      Integer index = idToIndex.get(id);
+      if (index == null) {
+        index = idToIndex.size();
+        indexToId.put(index, id);
+        idToIndex.put(id, index);
+      }
+      return index;
     }
-    return index;
   }
 
   public UUID domainId(int index) {
-    UUID id = indexToId.get(index);
-    if (id == null) {
-      throw new IllegalArgumentException("There is no domain id with index: " + index);
+    synchronized (this) {
+      UUID id = indexToId.get(index);
+      if (id == null) {
+        throw new IllegalArgumentException("There is no domain id with index: " + index);
+      }
+      return id;
     }
-    return id;
   }
 
 }

--- a/common/src/main/java/net/whimxiqal/journey/scope/ScopeManager.java
+++ b/common/src/main/java/net/whimxiqal/journey/scope/ScopeManager.java
@@ -32,6 +32,7 @@ import net.whimxiqal.journey.Journey;
 import net.whimxiqal.journey.JourneyPlayer;
 import net.whimxiqal.journey.Scope;
 import net.whimxiqal.journey.VirtualMap;
+import net.whimxiqal.journey.data.Waypoint;
 import net.whimxiqal.journey.message.Formatter;
 import net.whimxiqal.journey.search.DomainGoalSearchSession;
 import net.whimxiqal.journey.search.InternalScope;
@@ -48,21 +49,19 @@ public class ScopeManager {
     register(Journey.NAME, "personal", Scope.builder()
         .name(Component.text("My Waypoints"))
         .destinations(player -> VirtualMap.of(
-            () -> Journey.get().proxy().dataManager().personalWaypointManager()
+            () -> Journey.get().cachedDataProvider().personalWaypointCache()
                 .getAll(player.uuid(), false)
-                .entrySet()
                 .stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, entry -> Destination.of(entry.getValue()))),
+                .collect(Collectors.toMap(Waypoint::name, waypoint -> Destination.of(waypoint.location()))),
             Journey.get().proxy().dataManager().personalWaypointManager().getCount(player.uuid(), false)))
         .permission(Permission.PATH_PERSONAL.path())
         .build());
     register(Journey.NAME, "server", Scope.builder()
         .name(Component.text("Server Waypoints"))
         .destinations(player -> VirtualMap.of(
-            () -> Journey.get().proxy().dataManager().publicWaypointManager().getAll()
-                .entrySet()
+            () -> Journey.get().cachedDataProvider().publicWaypointCache().getAll()
                 .stream()
-                .collect(Collectors.toMap(Map.Entry::getKey, entry -> Destination.of(entry.getValue()))),
+                .collect(Collectors.toMap(Waypoint::name, waypoint -> Destination.of(waypoint.location()))),
             Journey.get().proxy().dataManager().publicWaypointManager().getCount()))
         .permission(Permission.PATH_SERVER.path())
         .build());
@@ -82,10 +81,10 @@ public class ScopeManager {
                     .description(Formatter.dull("Go to this player"))
                     .permission(Permission.PATH_PLAYER_WAYPOINTS.path())
                     .destinations(VirtualMap.of(
-                        () -> Journey.get().proxy().dataManager().personalWaypointManager().getAll(p.uuid(), true)
-                            .entrySet()
+                        () -> Journey.get().cachedDataProvider().personalWaypointCache()
+                            .getAll(p.uuid(), true)
                             .stream()
-                            .collect(Collectors.toMap(Map.Entry::getKey, entry -> Destination.of(entry.getValue()))),
+                            .collect(Collectors.toMap(Waypoint::name, waypoint -> Destination.of(waypoint.location()))),
                         Journey.get().proxy().dataManager().personalWaypointManager().getCount(p.uuid(), true)))
                     .build()))
                 .strict()  // to access any player destinations, you must at least scope to the player

--- a/common/src/main/java/net/whimxiqal/journey/search/DestinationPathTrial.java
+++ b/common/src/main/java/net/whimxiqal/journey/search/DestinationPathTrial.java
@@ -44,7 +44,6 @@ public class DestinationPathTrial extends PathTrial {
 
   public static final double SUFFICIENT_COMPLETION_DISTANCE_SQUARED = 0;
   public static final double COST_FUNCTION_WEIGHT = 1.4;
-  private static final int MAX_PREPARED_CHUNKS = 10;
   private static boolean loggedMaxCacheHit = false;  // only log this message once
   @Getter
   private final Cell destination;
@@ -148,11 +147,6 @@ public class DestinationPathTrial extends PathTrial {
         path.getCost(), path,
         ResultState.STOPPED_SUCCESSFUL,
         true, false);
-  }
-
-  @Override
-  protected void prepareIo() {
-    chunkCache.prepareChunks(upcoming.peek().getData().location(), destination, MAX_PREPARED_CHUNKS);
   }
 
   @Override

--- a/common/src/main/java/net/whimxiqal/journey/search/PathTrial.java
+++ b/common/src/main/java/net/whimxiqal/journey/search/PathTrial.java
@@ -186,10 +186,6 @@ public class PathTrial implements WorkItem {
     state = ResultState.IDLE;
   }
 
-  protected void prepareIo() {
-    // nothing by default
-  }
-
   /**
    * Attempt to calculate a path given some modes of transportation.
    */
@@ -210,7 +206,6 @@ public class PathTrial implements WorkItem {
     if (state.isStopped()) {
       return true;
     }
-    // Dispatch a starting event
     if (state == ResultState.IDLE) {
       Journey.logger().debug(this + ": path trial beginning");
       startExecutionTime = System.currentTimeMillis();
@@ -232,8 +227,6 @@ public class PathTrial implements WorkItem {
 
     Node current;
     while (!upcoming.isEmpty()) {
-      // Queue any IO we will likely needed
-      prepareIo();
 
       if (shouldDelay(animationDelayMs)) {
         return false;  // (not done)

--- a/common/src/main/java/net/whimxiqal/journey/stats/StatsManager.java
+++ b/common/src/main/java/net/whimxiqal/journey/stats/StatsManager.java
@@ -39,27 +39,32 @@ public class StatsManager {
   private int storedBlocksTravelled = 0;  // per hour
 
   public void initialize() {
-    if (task != null) {
-      throw new IllegalStateException("We're already initialized");
+    synchronized (this) {
+      if (task != null) {
+        throw new IllegalStateException("We're already initialized");
+      }
+      lastStored = System.currentTimeMillis();
+      reset();
+      task = Journey.get().proxy().schedulingManager().scheduleRepeat(this::store, false, UPDATE_PERIOD);
     }
-    lastStored = System.currentTimeMillis();
-    reset();
-    task = Journey.get().proxy().schedulingManager().scheduleRepeat(this::store, false, UPDATE_PERIOD);
   }
 
-  private synchronized void store() {
-    long now = System.currentTimeMillis();
-    if (now - lastStored < MS_PER_HOUR) {
-      return;
-    }
+  private void store() {
+    synchronized (this) {
+      long now = System.currentTimeMillis();
+      if (now - lastStored < MS_PER_HOUR) {
+        return;
+      }
 
-    lastStored = now;
-    storedSearches = searches;
-    storedBlocksTravelled = (int) Math.floor(blocksTravelled);
-    reset();
+      lastStored = now;
+      storedSearches = searches;
+      storedBlocksTravelled = (int) Math.floor(blocksTravelled);
+      reset();
+    }
   }
 
-  private synchronized void reset() {
+  private void reset() {
+    // already synchronized
     searches = 0;
     blocksTravelled = 0;
   }
@@ -67,31 +72,41 @@ public class StatsManager {
   /**
    * Increment the number of searches that have occurred. Thread-safe.
    */
-  public synchronized void incrementSearches() {
-    searches++;
+  public void incrementSearches() {
+    synchronized (this) {
+      searches++;
+    }
   }
 
   /**
    * Get the number of searches in the last hour. Thread-safe.
+   *
    * @return searches
    */
-  public synchronized int searches() {
-    return storedSearches;
+  public int searches() {
+    synchronized (this) {
+      return storedSearches;
+    }
   }
 
   /**
    * Increment the number of blocks that have been travelled. Thread-safe.
    */
   public synchronized void addBlocksTravelled(double blocks) {
-    blocksTravelled += blocks;
+    synchronized (this) {
+      blocksTravelled += blocks;
+    }
   }
 
   /**
    * Get the number of blocks travelled in the last hour. Thread-safe.
+   *
    * @return blocks travelled
    */
   public synchronized int blocksTravelled() {
-    return storedBlocksTravelled;
+    synchronized (this) {
+      return storedBlocksTravelled;
+    }
   }
 
   public void shutdown() {

--- a/common/src/main/java/net/whimxiqal/journey/util/Request.java
+++ b/common/src/main/java/net/whimxiqal/journey/util/Request.java
@@ -23,11 +23,13 @@
 
 package net.whimxiqal.journey.util;
 
+import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import javax.net.ssl.HttpsURLConnection;
 import net.whimxiqal.journey.Journey;
 import org.json.JSONObject;
 import org.json.JSONTokener;
@@ -48,8 +50,21 @@ public final class Request {
     Journey.get().proxy().schedulingManager().schedule(() -> {
       try {
         URL apiUrl = new URL("https://api.mojang.com/users/profiles/minecraft/" + player);
-        URLConnection yc = apiUrl.openConnection();
-        JSONObject obj = new JSONObject(new JSONTokener(new InputStreamReader(yc.getInputStream())));
+        URLConnection connection = apiUrl.openConnection();
+        if (!(connection instanceof HttpsURLConnection httpsConnection)) {
+          future.complete(null);
+          return;
+        }
+        httpsConnection.setRequestMethod("GET");
+        switch (httpsConnection.getResponseCode()) {
+          case HttpsURLConnection.HTTP_OK:
+            break;
+          default:
+            Journey.logger().warn("Mojang API request for player " + player + " resulted in response code: " + httpsConnection.getResponseCode());
+            future.complete(null);
+            return;
+        }
+        JSONObject obj = new JSONObject(new JSONTokener(new InputStreamReader(httpsConnection.getInputStream())));
 
         String hexString = obj.getString("id");
         byte[] uuidBytes = new byte[hexString.length() / 2];
@@ -59,7 +74,7 @@ public final class Request {
           uuidBytes[i] = (byte) Integer.parseInt(hexString.substring(stringIndex, stringIndex + 2), 16);
         }
         future.complete(UUIDUtil.bytesToUuid(uuidBytes));
-      } catch (Exception e) {
+      } catch (IOException e) {
         e.printStackTrace();
         future.complete(null);
       }

--- a/common/src/main/java/net/whimxiqal/journey/util/Request.java
+++ b/common/src/main/java/net/whimxiqal/journey/util/Request.java
@@ -25,11 +25,11 @@ package net.whimxiqal.journey.util;
 
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLConnection;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import javax.net.ssl.HttpsURLConnection;
 import net.whimxiqal.journey.Journey;
 import org.json.JSONObject;
 import org.json.JSONTokener;
@@ -51,13 +51,13 @@ public final class Request {
       try {
         URL apiUrl = new URL("https://api.mojang.com/users/profiles/minecraft/" + player);
         URLConnection connection = apiUrl.openConnection();
-        if (!(connection instanceof HttpsURLConnection httpsConnection)) {
+        if (!(connection instanceof HttpURLConnection httpsConnection)) {
           future.complete(null);
           return;
         }
         httpsConnection.setRequestMethod("GET");
         switch (httpsConnection.getResponseCode()) {
-          case HttpsURLConnection.HTTP_OK:
+          case HttpURLConnection.HTTP_OK:
             break;
           default:
             Journey.logger().warn("Mojang API request for player " + player + " resulted in response code: " + httpsConnection.getResponseCode());

--- a/common/src/main/java/net/whimxiqal/journey/util/Validator.java
+++ b/common/src/main/java/net/whimxiqal/journey/util/Validator.java
@@ -30,6 +30,8 @@ import java.util.regex.Pattern;
  */
 public final class Validator {
 
+  private static final String VALID_DATA_REGEX = "^[a-zA-Z0-9 -_]{1,30}$";
+
   private Validator() {
   }
 
@@ -45,7 +47,7 @@ public final class Validator {
     if (name.equalsIgnoreCase("help")) {
       return true;
     }
-    return !Pattern.matches("^[a-zA-Z][a-zA-Z0-9 -_]{1,30}[a-zA-Z0-9]$", name);
+    return !Pattern.matches(VALID_DATA_REGEX, name);
   }
 
 }

--- a/common/src/test/java/net/whimxiqal/journey/data/TestPublicWaypointManager.java
+++ b/common/src/test/java/net/whimxiqal/journey/data/TestPublicWaypointManager.java
@@ -23,61 +23,48 @@
 
 package net.whimxiqal.journey.data;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.LinkedList;
+import java.util.List;
 import net.whimxiqal.journey.Cell;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class TestPublicWaypointManager implements PublicWaypointManager {
 
-  private final Map<String, Cell> waypoints = new HashMap<>();
+  private final List<Waypoint> waypoints = new LinkedList<>();
 
   @Override
   public void add(@NotNull Cell cell, @NotNull String name) throws IllegalArgumentException, DataAccessException {
-    waypoints.put(name, cell);
+    waypoints.add(new Waypoint(name, cell, true));
   }
 
   @Override
   public void remove(@NotNull Cell cell) throws DataAccessException {
-    String toRemove = null;
-    for (Map.Entry<String, Cell> entry : waypoints.entrySet()) {
-      if (entry.getValue().equals(cell)) {
-        toRemove = entry.getKey();
-      }
-    }
-    if (toRemove != null) {
-      waypoints.remove(toRemove);
-    }
+    waypoints.removeIf(waypoint -> waypoint.location().equals(cell));
   }
 
   @Override
   public void remove(@NotNull String name) throws DataAccessException {
-    waypoints.remove(name);
+    waypoints.removeIf(waypoint -> waypoint.name().equals(name));
   }
 
   @Override
   public void renameWaypoint(String name, String newName) throws DataAccessException {
-    // ignore
+    throw new UnsupportedOperationException();
   }
 
   @Override
   public @Nullable String getName(@NotNull Cell cell) throws DataAccessException {
-    for (Map.Entry<String, Cell> entry : waypoints.entrySet()) {
-      if (entry.getValue().equals(cell)) {
-        return entry.getKey();
-      }
-    }
-    return null;
+    return waypoints.stream().filter(waypoint -> waypoint.location().equals(cell)).map(Waypoint::name).findFirst().orElse(null);
   }
 
   @Override
   public @Nullable Cell getWaypoint(@NotNull String name) throws DataAccessException {
-    return waypoints.get(name);
+    return waypoints.stream().filter(waypoint -> waypoint.name().equals(name)).map(Waypoint::location).findFirst().orElse(null);
   }
 
   @Override
-  public Map<String, Cell> getAll() throws DataAccessException {
+  public List<Waypoint> getAll() throws DataAccessException {
     return waypoints;
   }
 

--- a/common/src/test/java/net/whimxiqal/journey/manager/TestSchedulingManager.java
+++ b/common/src/test/java/net/whimxiqal/journey/manager/TestSchedulingManager.java
@@ -209,7 +209,7 @@ public class TestSchedulingManager implements SchedulingManager {
     schedulingManager.cancelTask(taskUuid1.get());
     schedulingManager.cancelTask(taskUuid2.get());
 
-    // test exceptions don't stop new scheduled tasks
+    // make sure exceptions don't stop new scheduled tasks
     schedulingManager.schedule(() -> {
       throw new RuntimeException();
     }, true);

--- a/common/src/test/java/net/whimxiqal/journey/schematic/SchematicSearchTests.java
+++ b/common/src/test/java/net/whimxiqal/journey/schematic/SchematicSearchTests.java
@@ -36,6 +36,7 @@ import net.whimxiqal.journey.Cell;
 import net.whimxiqal.journey.InternalJourneyPlayer;
 import net.whimxiqal.journey.Journey;
 import net.whimxiqal.journey.TestProxy;
+import net.whimxiqal.journey.manager.TestSchedulingManager;
 import net.whimxiqal.journey.navigation.Mode;
 import net.whimxiqal.journey.navigation.mode.JumpMode;
 import net.whimxiqal.journey.navigation.mode.WalkMode;
@@ -129,11 +130,14 @@ public class SchematicSearchTests {
       Journey.logger().setLevel(CommonLogger.LogLevel.DEBUG);
     }
 
-    if (!Journey.get().init()) {
-      Assertions.fail("Journey initialization failed");
-    }
+    proxy.schedulingManager().initialize();  // initialize early so that we can schedule on main thread
+    TestSchedulingManager.runOnMainThread(() -> {
+      if (!Journey.get().init()) {
+        Assertions.fail("Journey initialization failed");
+      }
 
-    Journey.get().tunnelManager().register(player -> TestPlatformProxy.tunnels);
+      Journey.get().tunnelManager().register(player -> TestPlatformProxy.tunnels);
+    });
   }
 
   @AfterAll

--- a/common/src/test/java/net/whimxiqal/journey/util/RequestTest.java
+++ b/common/src/test/java/net/whimxiqal/journey/util/RequestTest.java
@@ -23,6 +23,7 @@
 
 package net.whimxiqal.journey.util;
 
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import net.whimxiqal.journey.JourneyTestHarness;
 import org.junit.jupiter.api.Assertions;
@@ -32,7 +33,9 @@ class RequestTest extends JourneyTestHarness {
 
   @Test
   public void testGetPlayerUuid() throws ExecutionException, InterruptedException {
-    Assertions.assertEquals("069a79f4-44e9-4726-a5be-fca90e38aaf5", Request.getPlayerUuidAsync("Notch").get().toString());
+    UUID notchUuid = Request.getPlayerUuidAsync("Notch").get();
+    Assertions.assertNotNull(notchUuid, "Request to get UUID failed");
+    Assertions.assertEquals("069a79f4-44e9-4726-a5be-fca90e38aaf5", notchUuid.toString(), "Request got the wrong UUID");
   }
 
 }


### PR DESCRIPTION
- fixes #53
- fixes #54 
- fixes #51 
- Introduces a caching layer to handle common waypoint data access, like tab completion
- Handle tab completion synchronously on the main thread by using cached data
- Handle player location accessing synchronously on the main thread
- Send warnings for improper internal access of non-thread-safe components from async threads
- Paths no longer send preliminary chunk cache requests
- The central chunk cache requests more chunks for chunks surrounding the requested one
- The central chunk cache completes a limited number of chunk requests per tick
- Properly synchronize the stats manager
- Change scope name validation to accommodate Minecraft usernames