### PR TITLE
v1.1 Performance

### DIFF
--- a/api/src/main/java/net/whimxiqal/journey/TunnelSupplier.java
+++ b/api/src/main/java/net/whimxiqal/journey/TunnelSupplier.java
@@ -24,7 +24,6 @@
 package net.whimxiqal.journey;
 
 import java.util.Collection;
-import org.jetbrains.annotations.Nullable;
 
 /**
  * A supplier that gives a collection of tunnels when given a player.
@@ -40,6 +39,6 @@ public interface TunnelSupplier {
    * @return the tunnels
    */
   @Synchronous
-  Collection<? extends Tunnel> tunnels(@Nullable JourneyAgent player);
+  Collection<? extends Tunnel> tunnels(JourneyAgent player);
 
 }

--- a/bukkit/src/main/java/net/whimxiqal/journey/bukkit/chunk/BukkitSessionJourneyChunk.java
+++ b/bukkit/src/main/java/net/whimxiqal/journey/bukkit/chunk/BukkitSessionJourneyChunk.java
@@ -24,7 +24,6 @@
 package net.whimxiqal.journey.bukkit.chunk;
 
 import java.util.UUID;
-import net.whimxiqal.journey.Cell;
 import net.whimxiqal.journey.Journey;
 import net.whimxiqal.journey.chunk.ChunkId;
 import net.whimxiqal.journey.proxy.JourneyBlock;
@@ -49,6 +48,6 @@ public class BukkitSessionJourneyChunk implements JourneyChunk {
 
   @Override
   public JourneyBlock block(int x, int y, int z, FlagSet flagSet) {
-    return new BukkitSessionJourneyBlock(new Cell(id.x() * 16 + x, y, id.z() * 16 + z, id.domain()), chunk.getBlockData(x, y, z), chunk.getBlockData(x, y - 1, z), flagSet);
+    return new BukkitSessionJourneyBlock(JourneyChunk.toCell(id, x, y, z), chunk.getBlockData(x, y, z), chunk.getBlockData(x, y - 1, z), flagSet);
   }
 }

--- a/common/src/main/java/net/whimxiqal/journey/Journey.java
+++ b/common/src/main/java/net/whimxiqal/journey/Journey.java
@@ -23,7 +23,6 @@
 
 package net.whimxiqal.journey;
 
-import java.util.UUID;
 import net.whimxiqal.journey.chunk.CentralChunkCache;
 import net.whimxiqal.journey.config.Settings;
 import net.whimxiqal.journey.data.DataVersion;
@@ -44,7 +43,6 @@ import net.whimxiqal.journey.util.CommonLogger;
 public final class Journey {
 
   public static final String NAME = "Journey";
-  public static final UUID JOURNEY_CALLER = UUID.randomUUID();
   private static Journey instance;
   private final PlayerManager playerManager = new PlayerManager();
   private final NetherManager netherManager = new NetherManager();
@@ -120,9 +118,14 @@ public final class Journey {
   }
 
   public void shutdown() {
-    searchManager.shutdown();
-    statsManager.shutdown();
+    logger().setImmediateSubmit(true);
+    // shutdown cache first so any executing searches can continue with the completed chunks requests
     centralChunkCache.shutdown();
+
+    // shutdown search manager and wait for all ongoing searches to cancel and complete
+    searchManager.shutdown();
+
+    statsManager.shutdown();
     animationManager.shutdown();
     cachedDataProvider.shutdown();
     proxy.shutdown();

--- a/common/src/main/java/net/whimxiqal/journey/Proxy.java
+++ b/common/src/main/java/net/whimxiqal/journey/Proxy.java
@@ -50,14 +50,17 @@ public interface Proxy {
   String version();
 
   default void initialize() {
+    // initialize scheduling manager first because most init/shutdown scripts need it
+    schedulingManager().initialize();
     logger().initialize();
     dataManager().initialize();
-    schedulingManager().initialize();
   }
 
   default void shutdown() {
     logger().shutdown();
     audienceProvider().close();
+
+    // shutdown scheduling manager last because most init/shutdown scripts need it
     schedulingManager().shutdown();
   }
 }

--- a/common/src/main/java/net/whimxiqal/journey/ProxyImpl.java
+++ b/common/src/main/java/net/whimxiqal/journey/ProxyImpl.java
@@ -106,9 +106,6 @@ public class ProxyImpl implements Proxy {
 
   @Override
   public PlatformProxy platform() {
-    if (!schedulingManager.isMainThread()) {
-      Journey.logger().warn("Platform proxy accessed on async thread. This is likely a bug, please notify the developer.");
-    }
     return platformProxy;
   }
 

--- a/common/src/main/java/net/whimxiqal/journey/chunk/CentralChunkCache.java
+++ b/common/src/main/java/net/whimxiqal/journey/chunk/CentralChunkCache.java
@@ -178,7 +178,10 @@ public class CentralChunkCache {
 
           // Not stored and not queued. Queue it.
           maybeRequest = new ChunkRequest(innerChunkId);
+
+          // (callback to add to request queue is always called on the main server thread)
           Journey.get().proxy().platform().toChunk(innerChunkId, chunkGeneration).thenAccept(completedRequestQueue::add);
+
           requestMap.put(innerChunkId, maybeRequest);
           if (isRequestedChunk) {
             // This is the actually requested one

--- a/common/src/main/java/net/whimxiqal/journey/chunk/ChunkCacheBlockProvider.java
+++ b/common/src/main/java/net/whimxiqal/journey/chunk/ChunkCacheBlockProvider.java
@@ -60,7 +60,7 @@ public class ChunkCacheBlockProvider implements BlockProvider {
     if (chunk == null) {
       // Not stored locally. We have to get the info from the central cache and cache the chunk locally for next time
       Future<JourneyChunk> future = Journey.get().centralChunkCache().getChunk(chunkId);
-      chunk = future.get();  // waits for future, will take at most 1 game tick
+      chunk = future.get();  // waits for future. This is a source of latency and future versions should look into freeing up cycles while this is waiting
       chunkCache.save(chunk);
     }
     return chunk.block(localX, cell.blockY(), localZ, flagSet);

--- a/common/src/main/java/net/whimxiqal/journey/config/Settings.java
+++ b/common/src/main/java/net/whimxiqal/journey/config/Settings.java
@@ -49,6 +49,9 @@ public final class Settings {
   public static final Setting<Integer> MAX_PATH_BLOCK_COUNT
       = new IntegerSetting("search.max-path-block-count", 10000, 10, 10000000);
 
+  public static final Setting<Boolean> ALLOW_CHUNK_GENERATION
+      = new BooleanSetting("search.chunk-gen.allow", false);
+
   public static final Setting<Integer> MAX_SEARCHES
       = new IntegerSetting("search.max-searches", 16, 0, 1000000);
 

--- a/common/src/main/java/net/whimxiqal/journey/data/cache/CachedDataProvider.java
+++ b/common/src/main/java/net/whimxiqal/journey/data/cache/CachedDataProvider.java
@@ -23,6 +23,8 @@
 
 package net.whimxiqal.journey.data.cache;
 
+import net.whimxiqal.journey.Journey;
+
 public class CachedDataProvider {
 
   private final PersonalWaypointCache personalWaypointCache = new PersonalWaypointCache();
@@ -34,6 +36,7 @@ public class CachedDataProvider {
   }
 
   public void shutdown() {
+    Journey.logger().debug("[Cached Data Provider] Shutting down...");
     personalWaypointCache().shutdown();
     // public waypoint cache does need to be shutdown
   }

--- a/common/src/main/java/net/whimxiqal/journey/manager/AnimationManager.java
+++ b/common/src/main/java/net/whimxiqal/journey/manager/AnimationManager.java
@@ -111,6 +111,7 @@ public class AnimationManager {
   }
 
   public void shutdown() {
+    Journey.logger().debug("[Animation Manager] Shutting down...");
     if (taskId != null) {
       Journey.get().proxy().schedulingManager().cancelTask(taskId);
     }

--- a/common/src/main/java/net/whimxiqal/journey/manager/DistributedWorkManager.java
+++ b/common/src/main/java/net/whimxiqal/journey/manager/DistributedWorkManager.java
@@ -152,6 +152,7 @@ public class DistributedWorkManager {
     /**
      * Sets the work executor as inactive, and returns whether the
      * owner is done with all its active work.
+     *
      * @return true if the owner has no more active work, false if there is still some active work
      */
     private boolean setInactive() {

--- a/common/src/main/java/net/whimxiqal/journey/manager/DistributedWorkManager.java
+++ b/common/src/main/java/net/whimxiqal/journey/manager/DistributedWorkManager.java
@@ -121,7 +121,8 @@ public class DistributedWorkManager {
         synchronized (manager.lock) {
           boolean targetOwnerDone = target.setInactive();
           if (targetOwnerDone) {
-            // This owner is done, so there are no more opportunities for any scheduled replacements to run.
+            // Some replacements may have been queued while this target was running.
+            // But, this owner is done, so there are no more opportunities for any scheduled replacements to run.
             // Just requeue them, and set the first one to active
             LinkedList<WorkItemExecutor> replacements = manager.workReplacementMap.remove(target.work.owner());
             if (replacements != null) {

--- a/common/src/main/java/net/whimxiqal/journey/navigation/PlatformProxy.java
+++ b/common/src/main/java/net/whimxiqal/journey/navigation/PlatformProxy.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import net.whimxiqal.journey.Cell;
 import net.whimxiqal.journey.InternalJourneyPlayer;
@@ -51,12 +52,13 @@ public interface PlatformProxy extends BlockProvider {
 
   /**
    * Convert chunk id to a {@link JourneyChunk}.
-   * <b>Must be called on the main server thread!</b>
+   * <b>May be called async!</b>
    *
    * @param chunkId the chunk id
+   * @param generate true to generate the chunk if it doesn't exist, false to do nothing and complete the future null
    * @return the journey chunk
    */
-  JourneyChunk toChunk(ChunkId chunkId);
+  CompletableFuture<JourneyChunk> toChunk(ChunkId chunkId, boolean generate);
 
   /**
    * Convert a cell to a {@link JourneyBlock} with real-world data.

--- a/common/src/main/java/net/whimxiqal/journey/navigation/PlatformProxy.java
+++ b/common/src/main/java/net/whimxiqal/journey/navigation/PlatformProxy.java
@@ -53,10 +53,16 @@ public interface PlatformProxy extends BlockProvider {
   /**
    * Convert chunk id to a {@link JourneyChunk}.
    * <b>May be called async!</b>
+   * The returned future is always completed on the main server thread,
+   * so any callbacks thereafter are also synchronous on the main thread.
+   * The generate argument may be false if the caller does not want the server to generate the chunk
+   * if it hasn't already. If this is the case, the returned {@link JourneyChunk} will reflect the inaccessibility
+   * of the underlying chunk, given it is un-generated and unloaded.
+   * The returned future cannot be completed with null.
    *
    * @param chunkId the chunk id
-   * @param generate true to generate the chunk if it doesn't exist, false to do nothing and complete the future null
-   * @return the journey chunk
+   * @param generate true to generate the chunk if it doesn't exist
+   * @return the journey chunk future, to be completed on the main server thread
    */
   CompletableFuture<JourneyChunk> toChunk(ChunkId chunkId, boolean generate);
 

--- a/common/src/main/java/net/whimxiqal/journey/navigation/journey/PlayerJourneySession.java
+++ b/common/src/main/java/net/whimxiqal/journey/navigation/journey/PlayerJourneySession.java
@@ -126,9 +126,9 @@ public class PlayerJourneySession implements JourneySession {
         state = State.STOPPED_COMPLETE;
 
         // There is no other path after this one, we are done
-        Journey.get().proxy().audienceProvider().player(playerUuid).showTitle(Title.title(Component.empty(), Component.text("You have arrived", Formatter.THEME)));
+        Journey.get().proxy().audienceProvider().player(playerUuid).showTitle(Title.title(Component.empty(),
+                Component.text("You have arrived!").color(Formatter.SUCCESS)));
 
-        // Play a fun chord
         Journey.get().proxy().platform().playSuccess(playerUuid);
 
         stop();

--- a/common/src/main/java/net/whimxiqal/journey/proxy/JourneyChunk.java
+++ b/common/src/main/java/net/whimxiqal/journey/proxy/JourneyChunk.java
@@ -37,10 +37,11 @@ public interface JourneyChunk {
 
   /**
    * Get a cell from the given chunk id and coordinates within the chunk
+   *
    * @param id the chunk id
-   * @param x the x coordinate within the chunk [0-16)
-   * @param y the y coordinate
-   * @param z the z coordinate within the chunk [0-16)
+   * @param x  the x coordinate within the chunk [0-16)
+   * @param y  the y coordinate
+   * @param z  the z coordinate within the chunk [0-16)
    * @return the cell
    */
   static Cell toCell(ChunkId id, int x, int y, int z) {
@@ -57,9 +58,9 @@ public interface JourneyChunk {
   /**
    * Get the block at the given coordinates within the chunk.
    *
-   * @param x the x coordinate [0-16)
-   * @param y the y coordinate
-   * @param z the z coordinate [0-16)
+   * @param x       the x coordinate [0-16)
+   * @param y       the y coordinate
+   * @param z       the z coordinate [0-16)
    * @param flagSet the set of flags that may modify world/block behavior
    * @return the block
    */

--- a/common/src/main/java/net/whimxiqal/journey/proxy/JourneyChunk.java
+++ b/common/src/main/java/net/whimxiqal/journey/proxy/JourneyChunk.java
@@ -23,6 +23,7 @@
 
 package net.whimxiqal.journey.proxy;
 
+import net.whimxiqal.journey.Cell;
 import net.whimxiqal.journey.chunk.ChunkId;
 import net.whimxiqal.journey.search.flag.FlagSet;
 
@@ -33,6 +34,18 @@ import net.whimxiqal.journey.search.flag.FlagSet;
 public interface JourneyChunk {
 
   int CHUNK_SIDE_LENGTH = 16;
+
+  /**
+   * Get a cell from the given chunk id and coordinates within the chunk
+   * @param id the chunk id
+   * @param x the x coordinate within the chunk [0-16)
+   * @param y the y coordinate
+   * @param z the z coordinate within the chunk [0-16)
+   * @return the cell
+   */
+  static Cell toCell(ChunkId id, int x, int y, int z) {
+    return new Cell(id.x() * 16 + x, y, id.z() * 16 + z, id.domain());
+  }
 
   /**
    * Get the identifiable parameters for this chunk.

--- a/common/src/main/java/net/whimxiqal/journey/proxy/UnavailableJourneyBlock.java
+++ b/common/src/main/java/net/whimxiqal/journey/proxy/UnavailableJourneyBlock.java
@@ -1,0 +1,72 @@
+package net.whimxiqal.journey.proxy;
+
+import java.util.Optional;
+import net.whimxiqal.journey.Cell;
+
+public record UnavailableJourneyBlock(Cell cell) implements JourneyBlock {
+
+  @Override
+  public boolean isAir() {
+    return false;
+  }
+
+  @Override
+  public boolean isNetherPortal() {
+    return false;
+  }
+
+  @Override
+  public boolean isWater() {
+    return false;
+  }
+
+  @Override
+  public boolean isPressurePlate() {
+    return false;
+  }
+
+  @Override
+  public boolean isClimbable() {
+    return false;
+  }
+
+  @Override
+  public boolean isPassable() {
+    return false;
+  }
+
+  @Override
+  public boolean isLaterallyPassable() {
+    return false;
+  }
+
+  @Override
+  public boolean isVerticallyPassable() {
+    return false;
+  }
+
+  @Override
+  public boolean canStandOn() {
+    return false;
+  }
+
+  @Override
+  public boolean canStandIn() {
+    return false;
+  }
+
+  @Override
+  public float hardness() {
+    return Float.MAX_VALUE;
+  }
+
+  @Override
+  public double height() {
+    return Double.MAX_VALUE;
+  }
+
+  @Override
+  public Optional<JourneyDoor> asDoor() {
+    return Optional.empty();
+  }
+}

--- a/common/src/main/java/net/whimxiqal/journey/proxy/UnavailableJourneyChunk.java
+++ b/common/src/main/java/net/whimxiqal/journey/proxy/UnavailableJourneyChunk.java
@@ -1,0 +1,11 @@
+package net.whimxiqal.journey.proxy;
+
+import net.whimxiqal.journey.chunk.ChunkId;
+import net.whimxiqal.journey.search.flag.FlagSet;
+
+public record UnavailableJourneyChunk(ChunkId id) implements JourneyChunk {
+  @Override
+  public JourneyBlock block(int x, int y, int z, FlagSet flagSet) {
+    return new UnavailableJourneyBlock(JourneyChunk.toCell(id, x, y, z));
+  }
+}

--- a/common/src/main/java/net/whimxiqal/journey/search/DestinationPathTrial.java
+++ b/common/src/main/java/net/whimxiqal/journey/search/DestinationPathTrial.java
@@ -43,7 +43,7 @@ import net.whimxiqal.journey.search.function.WeightedDistanceCostFunction;
 public class DestinationPathTrial extends PathTrial {
 
   public static final double SUFFICIENT_COMPLETION_DISTANCE_SQUARED = 0;
-  public static final double COST_FUNCTION_WEIGHT = 1.4;
+  public static final double COST_FUNCTION_WEIGHT = 1.7;
   private static boolean loggedMaxCacheHit = false;  // only log this message once
   @Getter
   private final Cell destination;

--- a/common/src/main/java/net/whimxiqal/journey/search/PathTrial.java
+++ b/common/src/main/java/net/whimxiqal/journey/search/PathTrial.java
@@ -222,7 +222,9 @@ public class PathTrial implements WorkItem {
     // Start actual execution
     int startingCycleCount = visited.size();  // tracker to make sure we have short work cycles
     int animationDelayMs = session.flags.getValueFor(Flags.ANIMATE);
-    boolean isAnimating = animationDelayMs > 0;
+    boolean isAnimating = animationDelayMs > 0 && session.callerType == SearchSession.Caller.PLAYER;
+    // caller has to be a PLAYER if animation flag was set, but just check to be sure so we know the caller id
+    // is the id of a player
 
     Node current;
     while (!upcoming.isEmpty()) {

--- a/common/src/main/java/net/whimxiqal/journey/stats/StatsManager.java
+++ b/common/src/main/java/net/whimxiqal/journey/stats/StatsManager.java
@@ -110,6 +110,7 @@ public class StatsManager {
   }
 
   public void shutdown() {
+    Journey.logger().debug("[Stats Manager] Shutting down...");
     if (task != null) {
       Journey.get().proxy().schedulingManager().cancelTask(task);
       task = null;

--- a/common/src/test/java/net/whimxiqal/journey/platform/TestPlatformProxy.java
+++ b/common/src/test/java/net/whimxiqal/journey/platform/TestPlatformProxy.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import net.whimxiqal.journey.Cell;
@@ -60,8 +61,8 @@ public class TestPlatformProxy implements PlatformProxy {
   public static int animatedBlocks = 0;
 
   @Override
-  public JourneyChunk toChunk(ChunkId chunkId) {
-    return new TestJourneyChunk(chunkId);
+  public CompletableFuture<JourneyChunk> toChunk(ChunkId chunkId, boolean generate) {
+    return CompletableFuture.completedFuture(new TestJourneyChunk(chunkId));
   }
 
   @Override

--- a/common/src/test/java/net/whimxiqal/journey/schematic/SchematicChunk.java
+++ b/common/src/test/java/net/whimxiqal/journey/schematic/SchematicChunk.java
@@ -40,7 +40,7 @@ public record SchematicChunk(ChunkId chunkId, Clipboard clipboard) implements Jo
 
   @Override
   public JourneyBlock block(int x, int y, int z, FlagSet flagSet) {
-    Cell cell = new Cell(chunkId.x() * CHUNK_SIDE_LENGTH + x, y, chunkId.z() * CHUNK_SIDE_LENGTH + z, 0);
+    Cell cell = JourneyChunk.toCell(chunkId, x, y, z);
     return new SchematicBlock(cell, clipboard.getBlock(BlockVector3.at(cell.blockX(), cell.blockY(), cell.blockZ())).getBlockType());
   }
 }

--- a/common/src/test/java/net/whimxiqal/journey/schematic/SchematicPlatformProxy.java
+++ b/common/src/test/java/net/whimxiqal/journey/schematic/SchematicPlatformProxy.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import net.whimxiqal.journey.Cell;
@@ -55,8 +56,8 @@ public class SchematicPlatformProxy implements PlatformProxy {
   }
 
   @Override
-  public JourneyChunk toChunk(ChunkId chunkId) {
-    return new SchematicChunk(chunkId, clipboard.get());
+  public CompletableFuture<JourneyChunk> toChunk(ChunkId chunkId, boolean generate) {
+    return CompletableFuture.completedFuture(new SchematicChunk(chunkId, clipboard.get()));
   }
 
   @Override


### PR DESCRIPTION
- adds config setting to disallow Journey from generating new chunks
- moves chunk requests queueing to Paper's managed process to better manage the load on main thread
- wraps tunnels in a try-catch to gracefully handle errors from callables given through the API
- increases weight in the A* search for path trials to focus more on completion than optimality
- adds more debug logging
- changes the success message after navigating to the color green
- adds log truncation if logging is too frequent for whatever reason